### PR TITLE
Tox.ini - Removed capturing stdout on pytests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -24,4 +24,4 @@ deps =
 ;     -r{toxinidir}/requirements.txt
 commands =
     pip install -U pip
-    py.test --cov-branch --cov-report term-missing --cov-report xml --cov=evalutils --basetemp={envtmpdir}
+    py.test -s --cov-branch --cov-report term-missing --cov-report xml --cov=evalutils --basetemp={envtmpdir}


### PR DESCRIPTION
Required for better testing the processor templating