### PR TITLE
improved type annotations in stats.py

### DIFF
--- a/evalutils/stats.py
+++ b/evalutils/stats.py
@@ -109,7 +109,7 @@ def distance_transform_edt_float32(  # noqa: C901
     dt_inplace = isinstance(distances, np.ndarray)
 
     # calculate the feature transform
-    input_data = np.atleast_1d(input > 0)
+    input_data = np.atleast_1d(input != 0)
     input_data_check = input_data.nbytes >= gc_byte_threshold
 
     def garbage_collect():

--- a/evalutils/stats.py
+++ b/evalutils/stats.py
@@ -14,13 +14,13 @@ VOXELSPACING_TYPE = Optional[
 
 
 def distance_transform_edt_float32(  # noqa: C901
-    input: ndarray,
-    sampling: VOXELSPACING_TYPE = None,
-    return_distances: bool = True,
-    return_indices: bool = False,
-    distances: Optional[ndarray] = None,
-    indices: Optional[ndarray] = None,
-) -> Union[ndarray, List[ndarray]]:
+    input,
+    sampling=None,
+    return_distances=True,
+    return_indices=False,
+    distances=None,
+    indices=None,
+):
     """
     The same as scipy.ndimage.morphology.distance_transform_edt but
     using float32 and better memory cleaning internally.
@@ -30,25 +30,25 @@ def distance_transform_edt_float32(  # noqa: C901
     element is returned along the first axis of the result.
     Parameters
     ----------
-    input
+    input : array_like
         Input data to transform. Can be any type but will be converted
         into binary: 1 wherever input equates to True, 0 elsewhere.
-    sampling
+    sampling : float or int, or sequence of same, optional
         Spacing of elements along each dimension. If a sequence, must be of
         length equal to the input rank; if a single number, this is used for
         all axes. If not specified, a grid spacing of unity is implied.
-    return_distances
+    return_distances : bool, optional
         Whether to return distance matrix. At least one of
         return_distances/return_indices must be True. Default is True.
-    return_indices
+    return_indices : bool, optional
         Whether to return indices matrix. Default is False.
-    distances
+    distances : ndarray, optional
         Used for output of distance array, must be of type float64.
-    indices
+    indices : ndarray, optional
         Used for output of indices, must be of type int32.
     Returns
     -------
-    distance_transform_edt
+    distance_transform_edt : ndarray or list of ndarrays
         Either distance matrix, index matrix, or a list of the two,
         depending on `return_x` flags and `distance` and `indices`
         input parameters.

--- a/evalutils/stats.py
+++ b/evalutils/stats.py
@@ -20,6 +20,7 @@ def distance_transform_edt_float32(  # noqa: C901
     return_indices: bool = False,
     distances: Optional[ndarray] = None,
     indices: Optional[ndarray] = None,
+    gc_byte_threshold: int = 100000000,
 ):
     """
     The same as scipy.ndimage.morphology.distance_transform_edt but
@@ -46,6 +47,9 @@ def distance_transform_edt_float32(  # noqa: C901
         Used for output of distance array, must be of type float64.
     indices : ndarray, optional
         Used for output of indices, must be of type int32.
+    gc_byte_threshold : int, optional
+        Number of bytes that the input needs to exceed before
+        garbage collection and memory cleanup routines are called.
     Returns
     -------
     distance_transform_edt : ndarray or list of ndarrays
@@ -105,8 +109,8 @@ def distance_transform_edt_float32(  # noqa: C901
     dt_inplace = isinstance(distances, np.ndarray)
 
     # calculate the feature transform
-    input_data = np.atleast_1d(np.where(input, 1, 0).astype(np.int8))
-    input_data_check = input_data.nbytes > 100e6
+    input_data = np.atleast_1d(input > 0)
+    input_data_check = input_data.nbytes >= gc_byte_threshold
 
     def garbage_collect():
         nonlocal input_data_check

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -17,14 +17,6 @@ def reset_seeds():
     yield
 
 
-def test_edt32_gc():
-    x = np.random.random((100,)) > 0.5
-    indices = np.zeros((x.ndim,) + x.shape, dtype=np.int32)
-    stats.distance_transform_edt_float32(
-        input=x, sampling=[1.2], gc_byte_threshold=99, indices=indices
-    )
-
-
 @pytest.mark.parametrize(
     "shape, dtype", (((12,), np.int32), ((10, 2), np.int32), ((10,), np.int8))
 )

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -15,6 +15,32 @@ def reset_seeds():
     yield
 
 
+def test_edt32_gc():
+    x = np.random.random((100,)) > 0.5
+    indices = np.zeros((x.ndim,) + x.shape, dtype=np.int32)
+    stats.distance_transform_edt_float32(
+        input=x, sampling=[1.2], gc_byte_threshold=99, indices=indices
+    )
+
+
+def test_edt32_indices_wrong_shape():
+    x = np.random.random((10,)) > 0.5
+    indices = np.zeros((x.ndim, 12), dtype=np.int32)
+    with pytest.raises(RuntimeError):
+        stats.distance_transform_edt_float32(
+            input=x, sampling=[1.2], indices=indices
+        )
+
+
+def test_edt32_indices_wrong_dtype():
+    x = np.random.random((10,)) > 0.5
+    indices = np.zeros((x.ndim,) + x.shape, dtype=np.int8)
+    with pytest.raises(RuntimeError):
+        stats.distance_transform_edt_float32(
+            input=x, sampling=[1.2], indices=indices
+        )
+
+
 @pytest.mark.parametrize(
     "y_true", [np.random.randint(0, 2, (30, 20, 10)).astype(np.int)]
 )

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,3 +1,5 @@
+from typing import Tuple
+
 import SimpleITK
 import numpy as np
 import pytest
@@ -23,18 +25,12 @@ def test_edt32_gc():
     )
 
 
-def test_edt32_indices_wrong_shape():
+@pytest.mark.parametrize(
+    "shape, dtype", (((12,), np.int32), ((10, 2), np.int32), ((10,), np.int8))
+)
+def test_edt32_indices_wrong_format(shape: Tuple[int, ...], dtype: np.dtype):
     x = np.random.random((10,)) > 0.5
-    indices = np.zeros((x.ndim, 12), dtype=np.int32)
-    with pytest.raises(RuntimeError):
-        stats.distance_transform_edt_float32(
-            input=x, sampling=[1.2], indices=indices
-        )
-
-
-def test_edt32_indices_wrong_dtype():
-    x = np.random.random((10,)) > 0.5
-    indices = np.zeros((x.ndim,) + x.shape, dtype=np.int8)
+    indices = np.zeros((x.ndim,) + shape, dtype=dtype)
     with pytest.raises(RuntimeError):
         stats.distance_transform_edt_float32(
             input=x, sampling=[1.2], indices=indices


### PR DESCRIPTION
### The issue

I recently used the stats package of evalutils, but got some type annotation errors which were picked up by PyCharm.
Also running mypy on the package gave a lot of errors related to the stats.py package.
This PR aims to fix those.

### PR edits

* Extracted the `VOXELSPACING_TYPE`, since it can be quite different in appearance, all these formats are allowed:
  * `[1], 1, 2.0, [1,2,3], None, [1.0, 1.0], etc...`
* ~~Added type annotations to `distance_transform_edt_float32` method~~
* ~~pandas read_csv fix for pytests (3.7+), by explicitly setting the utf-8 encoding.~~
* ~~Refactored some code inside the `distance_transform_edt_float32` method to remove mypy errors.~~

### Additional notes
~~Pytests seem to work, but the pre-commit fails on the MyPy checks in the `distance_transform_edt_float32`~~