### PR TITLE
Added possibility to supply abbreviation letters for eval/algorithm choices

### DIFF
--- a/evalutils/cli.py
+++ b/evalutils/cli.py
@@ -43,7 +43,12 @@ def validate_python_module_name_fn(option):
 class AbbreviatedChoice(click.Choice):
     def __init__(self, choices: List[str]):
         super().__init__(choices=choices, case_sensitive=True)
-        self.abbreviations = [e[0] for e in choices]
+        self._abbreviations = [e[0].upper() for e in choices]
+        self._choices_upper = list(map(str.upper, choices))
+        if len(set(self._abbreviations)) != len(choices):
+            raise ValueError(
+                "First letters of choices for AbbreviatedChoices should be unique!"
+            )
 
     def get_metavar(self, param):
         return "[{}]".format(
@@ -52,11 +57,11 @@ class AbbreviatedChoice(click.Choice):
 
     def convert(self, value, param, ctx):
         value = value.upper()
-        if value in self.abbreviations:
-            value = self.choices[self.abbreviations.index(value)]
-        else:
-            value = value.title()
-        super().convert(value=value, param=param, ctx=ctx)
+        if value in self._abbreviations:
+            value = self.choices[self._abbreviations.index(value)]
+        elif value in self._choices_upper:
+            value = self.choices[self._choices_upper.index(value)]
+        return super().convert(value=value, param=param, ctx=ctx)
 
 
 @init.command(

--- a/tests/test_abbreviatedchoice.py
+++ b/tests/test_abbreviatedchoice.py
@@ -1,0 +1,26 @@
+import pytest
+
+from evalutils.cli import AbbreviatedChoice
+
+
+def test_abbreviated_choice_not_unique():
+    with pytest.raises(ValueError):
+        AbbreviatedChoice(choices=["Same", "same", "other"])
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    (
+        ("s", "same"),
+        ("S", "same"),
+        ("Same", "same"),
+        ("same", "same"),
+        ("other", "oTHER"),
+        ("O", "oTHER"),
+        ("o", "oTHER"),
+        ("OtHER", "oTHER"),
+    ),
+)
+def test_abbreviated_choice_convert(value: str, expected: str):
+    ac = AbbreviatedChoice(choices=["same", "oTHER"])
+    assert ac.convert(value=value, param=None, ctx=None) == expected


### PR DESCRIPTION
closes #291

This PR adds the option to supply abbreviation letters `C`, `S`, `D` for respectively `Classification`, `Segmentation`, and `Detection` choices for the optional `--kind` CLI parameter. 

* The implementation uses a custom `click.Choice` class, which internally converts abbreviated strings to the full form options.
* The default choice metavar is slightly adjusted to show the abbreviations as options.
* The old prompt list has been removed since it was shown twice, when the `--kind` argument wasn't specified.

This PR should probably wait until #299 lands to fix the pytests and mypy typing.