### PR TITLE
Minor performance boost for edt32 by using a more optimal mask converting routine

### DIFF
--- a/evalutils/stats.py
+++ b/evalutils/stats.py
@@ -105,7 +105,7 @@ def distance_transform_edt_float32(  # noqa: C901
     dt_inplace = isinstance(distances, np.ndarray)
 
     # calculate the feature transform
-    input = np.atleast_1d(np.where(input, 1, 0).astype(np.int8))
+    input = np.atleast_1d(input != 0)
 
     garbage_collect = gc.collect if input.nbytes > 100e6 else lambda: None
     garbage_collect()


### PR DESCRIPTION
Closes #302

This PR essentially replaces one line in the edt32 method in stats.py:

```python
 input = np.atleast_1d(np.where(input, 1, 0).astype(np.int8))
```
with:
```python
input = np.atleast_1d(input != 0)
```

They essentially perform the same operation, but the latter is approximately 3x as fast. See also #302 for proof and benchmark.
Also, the following nbytes check has the same number of bytes for `dtype=np.int8` and `dtype=np.bool`, keeping the behavior for the rest of the method the same.
