### PR TITLE
Added use_memory_efficient_edt switch to stats methods

### DIFF
--- a/evalutils/stats.py
+++ b/evalutils/stats.py
@@ -366,8 +366,9 @@ def __surface_distances(
         `scipy.ndimage.morphology.generate_binary_structure` and should usually
         be :math:`> 1`.
     use_memory_efficient_edt
-        When enabled it uses a float 32 version of the scipy euclidean distance
-        transform to reduce memory costs at the cost of some additional
+        When enabled it uses a float 32 version of the
+        `scipy.ndimage.morphology.distance_transform_edt`
+        to reduce memory costs at the cost of some additional
         compute time.
 
     Returns
@@ -429,8 +430,9 @@ def hausdorff_distance(
         `scipy.ndimage.morphology.generate_binary_structure` and should usually
         be :math:`> 1`.
     use_memory_efficient_edt
-        When enabled it uses a float 32 version of the scipy euclidean distance
-        transform to reduce memory costs at the cost of some additional
+        When enabled it uses a float 32 version of the
+        `scipy.ndimage.morphology.distance_transform_edt`
+        to reduce memory costs at the cost of some additional
         compute time.
 
     Returns
@@ -492,8 +494,9 @@ def percentile_hausdorff_distance(
         `scipy.ndimage.morphology.generate_binary_structure` and should usually
         be :math:`> 1`.
     use_memory_efficient_edt
-        When enabled it uses a float 32 version of the scipy euclidean distance
-        transform to reduce memory costs at the cost of some additional
+        When enabled it uses a float 32 version of the
+        `scipy.ndimage.morphology.distance_transform_edt`
+        to reduce memory costs at the cost of some additional
         compute time.
 
     Returns
@@ -559,8 +562,9 @@ def modified_hausdorff_distance(
         `scipy.ndimage.morphology.generate_binary_structure` and should usually
         be :math:`> 1`.
     use_memory_efficient_edt
-        When enabled it uses a float 32 version of the scipy euclidean distance
-        transform to reduce memory costs at the cost of some additional
+        When enabled it uses a float 32 version of the
+        `scipy.ndimage.morphology.distance_transform_edt`
+        to reduce memory costs at the cost of some additional
         compute time.
 
     Returns
@@ -694,8 +698,9 @@ def __directed_contour_distances(
         the input rank; if a single number, this is used for all axes. If
         not specified, a grid spacing of unity is implied.
     use_memory_efficient_edt
-        When enabled it uses a float 32 version of the scipy euclidean distance
-        transform to reduce memory costs at the cost of some additional
+        When enabled it uses a float 32 version of the
+        `scipy.ndimage.morphology.distance_transform_edt`
+        to reduce memory costs at the cost of some additional
         compute time.
 
     Returns
@@ -762,8 +767,9 @@ def mean_contour_distance(
         the input rank; if a single number, this is used for all axes. If
         not specified, a grid spacing of unity is implied.
     use_memory_efficient_edt
-        When enabled it uses a float 32 version of the scipy euclidean distance
-        transform to reduce memory costs at the cost of some additional
+        When enabled it uses a float 32 version of the
+        `scipy.ndimage.morphology.distance_transform_edt`
+        to reduce memory costs at the cost of some additional
         compute time.
 
     Returns
@@ -826,8 +832,9 @@ def hausdorff_distance_measures(
     percentile
         The percentile at which to calculate the Hausdorff Distance
     use_memory_efficient_edt
-        When enabled it uses a float 32 version of the scipy euclidean distance
-        transform to reduce memory costs at the cost of some additional
+        When enabled it uses a float 32 version of the
+        `scipy.ndimage.morphology.distance_transform_edt`
+        to reduce memory costs at the cost of some additional
         compute time.
 
     Returns

--- a/evalutils/stats.py
+++ b/evalutils/stats.py
@@ -338,7 +338,7 @@ def __surface_distances(
     s2: ndarray,
     voxelspacing: VOXELSPACING_TYPE = None,
     connectivity: int = 1,
-    use_memory_efficient_edt: bool = False,
+    use_memory_efficient_edt: bool = True,
 ) -> ndarray:
     """
     Computes set of surface distances.
@@ -404,7 +404,7 @@ def hausdorff_distance(
     s2: ndarray,
     voxelspacing: VOXELSPACING_TYPE = None,
     connectivity: int = 1,
-    use_memory_efficient_edt: bool = False,
+    use_memory_efficient_edt: bool = True,
 ) -> float:
     """
     Computes the (symmetric) Hausdorff Distance (HD) between the binary objects
@@ -463,7 +463,7 @@ def percentile_hausdorff_distance(
     percentile: Union[int, float] = 0.95,
     voxelspacing: VOXELSPACING_TYPE = None,
     connectivity: int = 1,
-    use_memory_efficient_edt: bool = False,
+    use_memory_efficient_edt: bool = True,
 ) -> float:
     """
     Nth Percentile Hausdorff Distance.
@@ -536,7 +536,7 @@ def modified_hausdorff_distance(
     s2: ndarray,
     voxelspacing: VOXELSPACING_TYPE = None,
     connectivity: int = 1,
-    use_memory_efficient_edt: bool = False,
+    use_memory_efficient_edt: bool = True,
 ) -> float:
     """
     Computes the (symmetric) Modified Hausdorff Distance (MHD) between the
@@ -672,7 +672,7 @@ def __directed_contour_distances(
     s1: ndarray,
     s2: ndarray,
     voxelspacing: VOXELSPACING_TYPE = None,
-    use_memory_efficient_edt: bool = False,
+    use_memory_efficient_edt: bool = True,
 ) -> ndarray:
     """
     Computes set of surface contour distances.
@@ -746,7 +746,7 @@ def mean_contour_distance(
     s1: ndarray,
     s2: ndarray,
     voxelspacing: VOXELSPACING_TYPE = None,
-    use_memory_efficient_edt: bool = False,
+    use_memory_efficient_edt: bool = True,
 ) -> float:
     """
     Computes the (symmetric) Mean Contour Distance between the binary objects
@@ -804,7 +804,7 @@ def hausdorff_distance_measures(
     voxelspacing: VOXELSPACING_TYPE = None,
     connectivity: int = 1,
     percentile: float = 0.95,
-    use_memory_efficient_edt: bool = False,
+    use_memory_efficient_edt: bool = True,
 ) -> HausdorffMeasures:
     """
     Returns multiple Hausdorff measures - (hd, modified_hd, percentile_hd)


### PR DESCRIPTION
Closes #303

### This PR 

* Adds a `use_memory_efficient_edt` switch to all methods computing edt transforms in stats.py.
* The default for the flag is set to the (non-memory-efficient) `scipy.ndimage.morphology.distance_transform_edt` version.
* When enabled it uses the `distance_transform_edt_float32` version in stats.py.
* Docstring has been added for the new parameter as well

@jmsmkn The current default was the memory-efficient version, but now it will use the (non-memory-efficient) `scipy.ndimage.morphology.distance_transform_edt` version. I figured that it would be more desirable to move away from custom methods. Is it ok to break it in this way, or would we rather put the default to the memory-efficient version we used before? 
