### PR TITLE
[#321] read from /dev/urandom using dd

### DIFF
--- a/evalutils/templates/algorithm/{{ cookiecutter.package_name }}/test.sh
+++ b/evalutils/templates/algorithm/{{ cookiecutter.package_name }}/test.sh
@@ -4,7 +4,7 @@ SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
 ./build.sh
 
-VOLUME_SUFFIX=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
+VOLUME_SUFFIX=$(dd if=/dev/urandom bs=32 count=1 | md5sum | cut --delimiter=' ' --fields=1)
 
 docker volume create {{ cookiecutter.package_name|lower }}-output-$VOLUME_SUFFIX
 

--- a/evalutils/templates/evaluation/{{ cookiecutter.package_name }}/test.sh
+++ b/evalutils/templates/evaluation/{{ cookiecutter.package_name }}/test.sh
@@ -4,7 +4,7 @@ SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
 ./build.sh
 
-VOLUME_SUFFIX=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
+VOLUME_SUFFIX=$(dd if=/dev/urandom bs=32 count=1 | md5sum | cut --delimiter=' ' --fields=1)
 
 docker volume create {{ cookiecutter.package_name|lower }}-output-$VOLUME_SUFFIX
 


### PR DESCRIPTION
Closes #321 
When generating SUFFIX_VOLUME the `test.sh` script uses `dd` to read from `/dev/urandom`