### PR TITLE
[comic#323] general improvements to generated build.sh and test.sh sc…

### DIFF
--- a/evalutils/templates/algorithm/{{ cookiecutter.package_name }}/build.sh
+++ b/evalutils/templates/algorithm/{{ cookiecutter.package_name }}/build.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
-SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
-docker build -t {{ cookiecutter.package_name|lower }} "$SCRIPTPATH"
+set -o errexit
+
+SCRIPTPATH="$(dirname "$(realpath "${0}")")"
+
+docker build -t {{ cookiecutter.package_name|lower }} "${SCRIPTPATH}"

--- a/evalutils/templates/algorithm/{{ cookiecutter.package_name }}/test.sh
+++ b/evalutils/templates/algorithm/{{ cookiecutter.package_name }}/test.sh
@@ -8,7 +8,7 @@ SCRIPTPATH="$(dirname "$(realpath "${0}")")"
 
 VOLUME_SUFFIX=$(dd if=/dev/urandom bs=32 count=1 | md5sum | cut --delimiter=' ' --fields=1)
 
-docker volume create "{{ cookiecutter.package_name|lower }-output-${VOLUME_SUFFIX}"
+docker volume create "{{ cookiecutter.package_name|lower }}-output-${VOLUME_SUFFIX}"
 
 docker run --rm \
         -v "${SCRIPTPATH}/test/":/input/ \

--- a/evalutils/templates/algorithm/{{ cookiecutter.package_name }}/test.sh
+++ b/evalutils/templates/algorithm/{{ cookiecutter.package_name }}/test.sh
@@ -1,31 +1,39 @@
 #!/usr/bin/env bash
 
-SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+set -o errexit
+
+SCRIPTPATH="$(dirname "$(realpath "${0}")")"
 
 ./build.sh
 
 VOLUME_SUFFIX=$(dd if=/dev/urandom bs=32 count=1 | md5sum | cut --delimiter=' ' --fields=1)
 
-docker volume create {{ cookiecutter.package_name|lower }}-output-$VOLUME_SUFFIX
+docker volume create "{{ cookiecutter.package_name|lower }-output-${VOLUME_SUFFIX}"
 
 docker run --rm \
-        -v $SCRIPTPATH/test/:/input/ \
-        -v {{ cookiecutter.package_name|lower }}-output-$VOLUME_SUFFIX:/output/ \
+        -v "${SCRIPTPATH}/test/":/input/ \
+        -v "{{ cookiecutter.package_name|lower }}-output-${VOLUME_SUFFIX}":/output/ \
         {{ cookiecutter.package_name|lower }}
 
 docker run --rm \
-        -v {{ cookiecutter.package_name|lower }}-output-$VOLUME_SUFFIX:/output/ \
-        {{ cookiecutter.docker_base_container }} cat /output/results.json | python -m json.tool
+        -v "{{ cookiecutter.package_name|lower }}-output-${VOLUME_SUFFIX}":/output/ \
+        {{ cookiecutter.docker_base_container }} cat /output/metrics.json | python -m json.tool
 
 docker run --rm \
-        -v {{ cookiecutter.package_name|lower }}-output-$VOLUME_SUFFIX:/output/ \
-        -v $SCRIPTPATH/test/:/input/ \
-        {{ cookiecutter.docker_base_container }} python -c "import json, sys; f1 = json.load(open('/output/results.json')); f2 = json.load(open('/input/expected_output.json')); sys.exit(f1 != f2);"
+        -v "{{ cookiecutter.package_name|lower }}-output-$VOLUME_SUFFIX":/output/ \
+        -v "${SCRIPTPATH}/test/":/input/ \
+        {{ cookiecutter.docker_base_container }} python -c "
+import json, sys
+jsn1 = json.load(open('/output/results.json'))
+jsn2 = json.load(open('/input/expected_output.json'))
+if(jsn1 != jsn2):
+    sys.exit(-1)
+"
 
 if [ $? -eq 0 ]; then
     echo "Tests successfully passed..."
 else
-    echo "Expected output was not found..."
+    echo "Expected output not found or the generated output did not match the expected output"
 fi
 
-docker volume rm {{ cookiecutter.package_name|lower }}-output-$VOLUME_SUFFIX
+docker volume rm "{{ cookiecutter.package_name|lower }}-output-${VOLUME_SUFFIX}"

--- a/evalutils/templates/evaluation/{{ cookiecutter.package_name }}/build.sh
+++ b/evalutils/templates/evaluation/{{ cookiecutter.package_name }}/build.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
-SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+set -o errexit
 
-docker build -t {{ cookiecutter.package_name|lower }} "$SCRIPTPATH"
+SCRIPTPATH="$(dirname "$(realpath "${0}")")"
+
+docker build -t {{ cookiecutter.package_name|lower }} "${SCRIPTPATH}"

--- a/evalutils/templates/evaluation/{{ cookiecutter.package_name }}/test.sh
+++ b/evalutils/templates/evaluation/{{ cookiecutter.package_name }}/test.sh
@@ -1,23 +1,35 @@
 #!/usr/bin/env bash
 
-set -o errexit
+# set -o errexit
 
+# RANDOM_READ_BYTES is tha amount of bytes to read from /dev/urandom.
+# No particular reason for any specific value, just something vaguely sensible that provides a
+# finite limit on reading from /dev/urandom and gives the message digest (here hard-coded to md5)
+# something to calculate on...
+RANDOM_READ_BYTES=1024
 SCRIPTPATH="$(dirname "$(realpath "${0}")")"
 
-./build.sh
+# echo "*** run ${SCRIPTPATH}/build.sh" >> "${TMPLOG}"
+# "${SCRIPTPATH}/build.sh"
 
-VOLUME_SUFFIX=$(dd if=/dev/urandom bs=32 count=1 | md5sum | cut --delimiter=' ' --fields=1)
+PACKAGE_NAME={{ cookiecutter.package_name|lower }}
+VOLUME_SUFFIX=$(dd if=/dev/urandom bs=${RANDOM_READ_BYTES} count=1 | md5sum | cut --delimiter=' ' --fields=1)
+VOLUME_NAME="${PACKAGE_NAME}-output-${VOLUME_SUFFIX}"
 
-docker volume create "{{ cookiecutter.package_name|lower }}-output-${VOLUME_SUFFIX}"
+echo "*** vol name ${VOLUME_NAME} ; docker vol create: "
+docker volume create "${VOLUME_NAME}"
 
+echo "*** last exec: $? : docker run"
 docker run --rm \
         --memory=4g \
         -v "${SCRIPTPATH/test/}":/input/ \
-        -v "{{ cookiecutter.package_name|lower }}-output-${VOLUME_SUFFIX}":/output/ \
-        {{ cookiecutter.package_name|lower }}
-
+        -v "${VOLUME_NAME}":/output/ \
+        "${PACKAGE_NAME}"   # cmd missing here? Or am I just mis-reading this?
+echo "*** last exec: $? : docker run cat json output"
 docker run --rm \
-        -v "{{ cookiecutter.package_name|lower }}-output-${VOLUME_SUFFIX}":/output/ \
-        {{ cookiecutter.docker_base_container }} cat /output/metrics.json | python -m json.tool
+        -v "${VOLUME_NAME}":/output/ \
+        "${PACKAGE_NAME}" cat /output/metrics.json | python -m json.tool
 
-docker volume rm {{ cookiecutter.package_name|lower }}-output-$VOLUME_SUFFIX
+echo "*** last exec: $? : docker volume rm"
+docker volume rm "${VOLUME_NAME}"
+echo "*** last exec: $? : done"

--- a/evalutils/templates/evaluation/{{ cookiecutter.package_name }}/test.sh
+++ b/evalutils/templates/evaluation/{{ cookiecutter.package_name }}/test.sh
@@ -1,21 +1,23 @@
 #!/usr/bin/env bash
 
-SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+set -o errexit
+
+SCRIPTPATH="$(dirname "$(realpath "${0}")")"
 
 ./build.sh
 
 VOLUME_SUFFIX=$(dd if=/dev/urandom bs=32 count=1 | md5sum | cut --delimiter=' ' --fields=1)
 
-docker volume create {{ cookiecutter.package_name|lower }}-output-$VOLUME_SUFFIX
+docker volume create "{{ cookiecutter.package_name|lower }}-output-${VOLUME_SUFFIX}"
 
 docker run --rm \
         --memory=4g \
-        -v $SCRIPTPATH/test/:/input/ \
-        -v {{ cookiecutter.package_name|lower }}-output-$VOLUME_SUFFIX:/output/ \
+        -v "${SCRIPTPATH/test/}":/input/ \
+        -v "{{ cookiecutter.package_name|lower }}-output-${VOLUME_SUFFIX}":/output/ \
         {{ cookiecutter.package_name|lower }}
 
 docker run --rm \
-        -v {{ cookiecutter.package_name|lower }}-output-$VOLUME_SUFFIX:/output/ \
+        -v "{{ cookiecutter.package_name|lower }}-output-${VOLUME_SUFFIX}":/output/ \
         {{ cookiecutter.docker_base_container }} cat /output/metrics.json | python -m json.tool
 
 docker volume rm {{ cookiecutter.package_name|lower }}-output-$VOLUME_SUFFIX

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -75,8 +75,8 @@ def test_evaluation_cli(tmpdir, kind, expected):
     out = out.decode().splitlines()
     start = [i for i, ln in enumerate(out) if ln == "{"]
     end = [i for i, ln in enumerate(out) if ln == "}"]
-    result = json.loads("\n".join(out[start[0] : (end[-1] + 1)]))
-
+    result = json.loads("\n".join(out[start[0]:(end[-1] + 1)])) if start and end else None
+    assert result
     check_dict(result, expected)
 
     files = os.listdir(project_dir)


### PR DESCRIPTION
Closes #323 

Just some general improvements for the build.sh and test.sh scripts, main items:
1. use of `set -o errexit` (same as `set -e` if you're more familiar with that)
2. double-quoting around shell variable expansions
3. use of {} around variable names to clearly delimit them (no bash shell variable manipulation in the {} as of yet)

I ran the tests, not sure what to make of it, they didn't fail, they didn't pass ;)

```
~/swdev/evalutils$ venv/bin/pytest setup.py test_templates.py
============================================== test session starts ==============================================
platform linux -- Python 3.8.10, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
Using --randomly-seed=2209544794
rootdir: /home/gabyvsdiag/swdev/evalutils, configfile: pytest.ini
plugins: randomly-3.10.1, forked-1.3.0, cov-3.0.0, xdist-2.4.0
gw0 [0] / gw1 [0] / gw2 [0]

============================================= no tests ran in 0.58s =============================================

```