### PR TITLE
Add isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,3 @@
-default_language_version:
-  python: python3.8
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.1.0
@@ -15,6 +13,10 @@ repos:
       - id: pyupgrade
         language: python
         args: [--py37-plus]
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
   - repo: https://github.com/ambv/black
     rev: 22.1.0
     hooks:
@@ -27,7 +29,6 @@ repos:
         language: python
         additional_dependencies:
           - flake8-bugbear
-          - flake8-import-order
           - pep8-naming
           # The following is disabled due to a runtime error
           # - flake8-docstrings

--- a/evalutils/io.py
+++ b/evalutils/io.py
@@ -4,10 +4,10 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Dict, List
 
-from SimpleITK import GetArrayFromImage, ReadImage
 from imageio import get_reader
 from pandas import read_csv
 from pandas.errors import EmptyDataError, ParserError
+from SimpleITK import GetArrayFromImage, ReadImage
 
 from .exceptions import FileLoaderError
 

--- a/evalutils/stats.py
+++ b/evalutils/stats.py
@@ -6,7 +6,6 @@ import numpy as np
 from numpy import ndarray
 from scipy.ndimage import binary_erosion, convolve, generate_binary_structure
 
-
 VOXELSPACING_TYPE = Optional[
     Union[Tuple[Union[float, int], ...], List[Union[float, int]], float, int]
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,11 @@ sphinx_autodoc_typehints = "*"
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
+[tool.isort]
+profile = "black"
+known_first_party = ["evalutils", "tests"]
+line_length = 79
+
 [tool.black]
 line-length = 79
 target-version = ['py37']

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,10 +6,7 @@ python_version = 3.9
 # disallow_untyped_defs = True
 
 [flake8]
-application-import-names =
-    evalutils
-    tests
-import-order-style = pycharm
+max-line-length = 79
 docstring-convention = numpy
 max-complexity = 10
 select =

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -4,8 +4,8 @@ import shutil
 from pathlib import Path
 from typing import Dict
 
-import SimpleITK
 import numpy as np
+import SimpleITK
 from pandas import DataFrame
 from scipy.ndimage import center_of_mass, label
 
@@ -14,7 +14,6 @@ from evalutils import (
     DetectionAlgorithm,
     SegmentationAlgorithm,
 )
-
 
 TEMPLATE_TEST_DIR = (
     Path(__file__).parent.parent

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,9 +1,9 @@
 from typing import Tuple
 
-import SimpleITK
 import numpy as np
 import pytest
 import scipy.ndimage as ndimage
+import SimpleITK
 import sklearn
 from numpy.testing import assert_array_almost_equal
 from scipy.ndimage import generate_binary_structure


### PR DESCRIPTION
This PR adds isort with the following changes:

- [x] `default_language_version` removed
- [x] pyupgrade args set correctly
- [x] `isort` added before `black`
- [x] `flake8-import-order` removed
- [x] `known_first_party` set correctly
- [x] `application-import-names` and `import-order-style` removed