### PR TITLE
Maximize pandas version to <2.0 as append is removed

### DIFF
--- a/evalutils/io.py
+++ b/evalutils/io.py
@@ -137,7 +137,7 @@ class ImageIOLoader(ImageLoader):
     @staticmethod
     def load_image(fname):
         with open(fname, "rb") as f:
-            with get_reader(f, mode="i", as_gray=True) as r:
+            with get_reader(f, mode="L") as r:
                 return r.get_data(0)
 
     @staticmethod

--- a/evalutils/io.py
+++ b/evalutils/io.py
@@ -137,7 +137,7 @@ class ImageIOLoader(ImageLoader):
     @staticmethod
     def load_image(fname):
         with open(fname, "rb") as f:
-            with get_reader(f, mode="L") as r:
+            with get_reader(f, mode="i") as r:
                 return r.get_data(0)
 
     @staticmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ click = "*"
 scipy = "*"
 scikit-learn = "*"
 numpy = ">=1.22"
-pandas = ">=1.3"
+pandas = ">=1.3,<2.0"
 pip-tools = ">=6"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
AttributeError: 'DataFrame' object has no attribute 'append' is thrown. Pandas 2.0 has removed 'append' as of April 2023. Short term solution is to require pandas version to be below 2.0. 