### PR TITLE
Fix dependenies upgrade issues

### DIFF
--- a/evalutils/evalutils.py
+++ b/evalutils/evalutils.py
@@ -586,8 +586,14 @@ class ClassificationEvaluation(BaseEvaluation):
     def score(self):
         self._case_results = DataFrame()
         for idx, case in self._cases.iterrows():
-            self._case_results = self._case_results.append(
-                self.score_case(idx=idx, case=case), ignore_index=True
+            self._case_results = concat(
+                [
+                    self._case_results,
+                    DataFrame.from_records(
+                        [self.score_case(idx=idx, case=case)]
+                    ),
+                ],
+                ignore_index=True,
             )
         self._aggregate_results = self.score_aggregates()
 
@@ -653,11 +659,20 @@ class DetectionEvaluation(BaseEvaluation):
         self._case_results = DataFrame()
 
         for idx, case in enumerate(cases):
-            self._case_results = self._case_results.append(
-                self.score_case(
-                    idx=idx,
-                    case=self._cases.loc[self._cases[self._join_key] == case],
-                ),
+            self._case_results = concat(
+                [
+                    self._case_results,
+                    DataFrame.from_records(
+                        [
+                            self.score_case(
+                                idx=idx,
+                                case=self._cases.loc[
+                                    self._cases[self._join_key] == case
+                                ],
+                            )
+                        ]
+                    ),
+                ],
                 ignore_index=True,
             )
         self._aggregate_results = self.score_aggregates()

--- a/evalutils/io.py
+++ b/evalutils/io.py
@@ -137,7 +137,7 @@ class ImageIOLoader(ImageLoader):
     @staticmethod
     def load_image(fname):
         with open(fname, "rb") as f:
-            with get_reader(f, mode="i") as r:
+            with get_reader(f, mode="i", pilmode="F") as r:
                 return r.get_data(0)
 
     @staticmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ click = "*"
 scipy = "*"
 scikit-learn = "*"
 numpy = ">=1.22"
-pandas = ">=1.3,<2.0"
+pandas = ">=1.3"
 pip-tools = ">=6"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ evalutils = "evalutils.__main__:main"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-imageio = { version = "*", extras=["tifffile"] }
+imageio = { version = ">=2.31", extras=["tifffile"] }
 # Exclude 2.1.1.1 due to
 # https://github.com/SimpleITK/SimpleITK/issues/1627
 # and https://github.com/python-poetry/poetry/issues/2453


### PR DESCRIPTION
Replaces pandas `append` function with `concat`, as `append` was [deprecated](https://pandas.pydata.org/docs/whatsnew/v2.0.0.html#deprecations) in version>2.

Waiting for a fix for [this issue](https://github.com/imageio/imageio/issues/991), which should enable us to replace `as_gray` with `pilomode="F"` in imagio get_reader `as_gray` was also [deprecated](https://imageio.readthedocs.io/en/stable/reference/userapi.html#caveats-and-notes).
